### PR TITLE
feat: support Authelia password change with OTC elevation retry

### DIFF
--- a/Authelia-Auth/Authelia-Auth.csproj
+++ b/Authelia-Auth/Authelia-Auth.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.Authelia_Auth</RootNamespace>
-    <AssemblyVersion>1.0.14.0</AssemblyVersion>
-    <FileVersion>1.0.14.0</FileVersion>
+    <AssemblyVersion>1.0.17.0</AssemblyVersion>
+    <FileVersion>1.0.17.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>

--- a/Authelia-Auth/AutheliaAuthenticationProviderPlugin.cs
+++ b/Authelia-Auth/AutheliaAuthenticationProviderPlugin.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Jellyfin.Data;
@@ -60,8 +61,19 @@ namespace Jellyfin.Plugin.Authelia_Auth
             var userManager = _applicationHost.Resolve<IUserManager>();
             var config = AutheliaPlugin.Instance.Configuration;
 
-            var auth = await new Authenticator().Authenticate(config, username, password);
-            CaptureCredentialForPasswordChangeFlow(username, password);
+            FlowCredential flowCredential = null;
+            var passwordForAuthentication = password;
+            if (TryGetCurrentHttpContext(out var httpContext) && IsPasswordChangeRoute(httpContext.Request.Path.Value ?? string.Empty))
+            {
+                ParsePasswordFlowInput(username, password, out passwordForAuthentication, out flowCredential);
+            }
+
+            var auth = await new Authenticator().Authenticate(config, username, passwordForAuthentication);
+
+            if (flowCredential != null)
+            {
+                CaptureCredentialForPasswordChangeFlow(username, flowCredential);
+            }
 
             User user;
             try
@@ -126,13 +138,18 @@ namespace Jellyfin.Plugin.Authelia_Auth
 
             try
             {
-                await new Authenticator().ChangePassword(config, username, flowCredential.GetPassword(), newPassword);
+                await new Authenticator().ChangePassword(
+                    config,
+                    username,
+                    flowCredential.GetPassword(),
+                    newPassword,
+                    flowCredential.GetOneTimeCode());
             }
             catch (PasswordChangeElevationRequiredException)
             {
                 throw new AuthenticationException(
                     $"Authelia requires an elevated session before changing passwords. "
-                    + $"Open {BuildAutheliaPortalUrl(config.AutheliaServer)} and change your password there.");
+                    + $"Open {BuildAutheliaPortalUrl(config.AutheliaServer)}, request an elevation code, and retry here with current password format: currentPassword::otc=YOURCODE.");
             }
             finally
             {
@@ -151,10 +168,45 @@ namespace Jellyfin.Plugin.Authelia_Auth
             return server;
         }
 
-        private void CaptureCredentialForPasswordChangeFlow(string username, string password)
+        private static void ParsePasswordFlowInput(string username, string passwordInput, out string password, out FlowCredential credential)
+        {
+            password = passwordInput;
+            credential = null;
+
+            if (string.IsNullOrEmpty(passwordInput))
+            {
+                return;
+            }
+
+            const string marker = "::otc=";
+            var markerIndex = passwordInput.LastIndexOf(marker, StringComparison.OrdinalIgnoreCase);
+            if (markerIndex <= 0)
+            {
+                credential = new FlowCredential(username, passwordInput, null);
+                return;
+            }
+
+            var rawPassword = passwordInput[..markerIndex];
+            var rawOneTimeCode = passwordInput[(markerIndex + marker.Length)..].Trim();
+
+            if (string.IsNullOrWhiteSpace(rawPassword)
+                || string.IsNullOrWhiteSpace(rawOneTimeCode)
+                || rawOneTimeCode.Length > 32
+                || !rawOneTimeCode.All(char.IsLetterOrDigit))
+            {
+                credential = new FlowCredential(username, passwordInput, null);
+                return;
+            }
+
+            password = rawPassword;
+            credential = new FlowCredential(username, rawPassword, rawOneTimeCode.ToUpperInvariant());
+        }
+
+        private void CaptureCredentialForPasswordChangeFlow(string username, FlowCredential newCredential)
         {
             if (!TryGetCurrentHttpContext(out var httpContext) || !IsPasswordChangeRoute(httpContext.Request.Path.Value ?? string.Empty))
             {
+                newCredential?.Clear();
                 return;
             }
 
@@ -164,7 +216,7 @@ namespace Jellyfin.Plugin.Authelia_Auth
                 existingCredential.Clear();
             }
 
-            httpContext.Items[key] = new FlowCredential(username, password);
+            httpContext.Items[key] = newCredential;
         }
 
         private FlowCredential TakeCredentialForPasswordChangeFlow(string username)
@@ -242,19 +294,27 @@ namespace Jellyfin.Plugin.Authelia_Auth
 
         private sealed class FlowCredential
         {
-            public FlowCredential(string username, string password)
+            public FlowCredential(string username, string password, string oneTimeCode)
             {
                 Username = username;
                 PasswordChars = password.ToCharArray();
+                OneTimeCodeChars = string.IsNullOrWhiteSpace(oneTimeCode) ? Array.Empty<char>() : oneTimeCode.ToCharArray();
             }
 
             public string Username { get; }
 
             private char[] PasswordChars { get; set; }
 
+            private char[] OneTimeCodeChars { get; set; }
+
             public string GetPassword()
             {
                 return new string(PasswordChars);
+            }
+
+            public string GetOneTimeCode()
+            {
+                return OneTimeCodeChars.Length == 0 ? null : new string(OneTimeCodeChars);
             }
 
             public void Clear()
@@ -263,6 +323,12 @@ namespace Jellyfin.Plugin.Authelia_Auth
                 {
                     Array.Clear(PasswordChars, 0, PasswordChars.Length);
                     PasswordChars = Array.Empty<char>();
+                }
+
+                if (OneTimeCodeChars.Length > 0)
+                {
+                    Array.Clear(OneTimeCodeChars, 0, OneTimeCodeChars.Length);
+                    OneTimeCodeChars = Array.Empty<char>();
                 }
             }
         }

--- a/Authelia-Auth/AutheliaAuthenticationProviderPlugin.cs
+++ b/Authelia-Auth/AutheliaAuthenticationProviderPlugin.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Security.Cryptography;
-using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
@@ -9,6 +8,7 @@ using MediaBrowser.Common;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Cryptography;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.Authelia_Auth
@@ -18,8 +18,6 @@ namespace Jellyfin.Plugin.Authelia_Auth
     /// </summary>
     public class AutheliaAuthenticationProviderPlugin : IAuthenticationProvider
     {
-        private static readonly AsyncLocal<FlowCredential> CurrentFlowCredential = new();
-
         private readonly IApplicationHost _applicationHost;
         private readonly ILogger<AutheliaAuthenticationProviderPlugin> _logger;
         private readonly ICryptoProvider _cryptoProvider;
@@ -63,7 +61,7 @@ namespace Jellyfin.Plugin.Authelia_Auth
             var config = AutheliaPlugin.Instance.Configuration;
 
             var auth = await new Authenticator().Authenticate(config, username, password);
-            CurrentFlowCredential.Value = new FlowCredential(username, password);
+            CaptureCredentialForPasswordChangeFlow(username, password);
 
             User user;
             try
@@ -115,13 +113,10 @@ namespace Jellyfin.Plugin.Authelia_Auth
 
             var username = user.Username;
             var config = AutheliaPlugin.Instance.Configuration;
-            var flowCredential = CurrentFlowCredential.Value;
+            var flowCredential = TakeCredentialForPasswordChangeFlow(username);
 
-            if (flowCredential == null || !string.Equals(flowCredential.Username, username, StringComparison.OrdinalIgnoreCase))
+            if (flowCredential == null)
             {
-                flowCredential?.Clear();
-                CurrentFlowCredential.Value = null;
-
                 throw new AuthenticationException(
                     $"Unable to change password from Jellyfin because the current password was not provided "
                     + $"in this password-change request. "
@@ -142,7 +137,6 @@ namespace Jellyfin.Plugin.Authelia_Auth
             finally
             {
                 flowCredential?.Clear();
-                CurrentFlowCredential.Value = null;
             }
         }
 
@@ -155,6 +149,95 @@ namespace Jellyfin.Plugin.Authelia_Auth
             }
 
             return server;
+        }
+
+        private void CaptureCredentialForPasswordChangeFlow(string username, string password)
+        {
+            if (!TryGetCurrentHttpContext(out var httpContext) || !IsPasswordChangeRoute(httpContext.Request.Path.Value ?? string.Empty))
+            {
+                return;
+            }
+
+            var key = BuildFlowCredentialKey(username);
+            if (httpContext.Items.TryGetValue(key, out var existing) && existing is FlowCredential existingCredential)
+            {
+                existingCredential.Clear();
+            }
+
+            httpContext.Items[key] = new FlowCredential(username, password);
+        }
+
+        private FlowCredential TakeCredentialForPasswordChangeFlow(string username)
+        {
+            if (!TryGetCurrentHttpContext(out var httpContext))
+            {
+                return null;
+            }
+
+            var key = BuildFlowCredentialKey(username);
+
+            if (!httpContext.Items.TryGetValue(key, out var value) || value is not FlowCredential credential)
+            {
+                return null;
+            }
+
+            httpContext.Items.Remove(key);
+
+            if (!string.Equals(credential.Username, username, StringComparison.OrdinalIgnoreCase))
+            {
+                credential.Clear();
+                return null;
+            }
+
+            return credential;
+        }
+
+        private bool TryGetCurrentHttpContext(out HttpContext httpContext)
+        {
+            httpContext = null;
+
+            IHttpContextAccessor accessor;
+            try
+            {
+                accessor = _applicationHost.Resolve<IHttpContextAccessor>();
+            }
+            catch
+            {
+                return false;
+            }
+
+            httpContext = accessor?.HttpContext;
+            return httpContext != null;
+        }
+
+        private static bool IsPasswordChangeRoute(string requestPath)
+        {
+            if (string.IsNullOrWhiteSpace(requestPath))
+            {
+                return false;
+            }
+
+            var segments = requestPath
+                .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            if (segments.Length < 2 || !segments[^1].Equals("Password", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (segments[^2].Equals("Users", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return segments.Length >= 3
+                && segments[^3].Equals("Users", StringComparison.OrdinalIgnoreCase)
+                && Guid.TryParse(segments[^2], out _);
+        }
+
+        private static string BuildFlowCredentialKey(string username)
+        {
+            return $"authelia-auth:password-flow:{username.ToLowerInvariant()}";
         }
 
         private sealed class FlowCredential

--- a/Authelia-Auth/AutheliaAuthenticationProviderPlugin.cs
+++ b/Authelia-Auth/AutheliaAuthenticationProviderPlugin.cs
@@ -8,6 +8,7 @@ using MediaBrowser.Common;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Cryptography;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.Authelia_Auth
@@ -27,7 +28,10 @@ namespace Jellyfin.Plugin.Authelia_Auth
         /// <param name="applicationHost">Instance of the <see cref="IApplicationHost"/> interface.</param>
         /// <param name="logger">Instance of the <see cref="ILogger{AutheliaAuthenticationProviderPlugin}"/> interface.</param>
         /// <param name="cryptoProvider">Instance of the <see cref="ILogger{ICryptoProvider}"/> interface.</param>
-        public AutheliaAuthenticationProviderPlugin(IApplicationHost applicationHost, ILogger<AutheliaAuthenticationProviderPlugin> logger, ICryptoProvider cryptoProvider)
+        public AutheliaAuthenticationProviderPlugin(
+            IApplicationHost applicationHost,
+            ILogger<AutheliaAuthenticationProviderPlugin> logger,
+            ICryptoProvider cryptoProvider)
         {
             _logger = logger;
             _applicationHost = applicationHost;
@@ -57,6 +61,7 @@ namespace Jellyfin.Plugin.Authelia_Auth
             var config = AutheliaPlugin.Instance.Configuration;
 
             var auth = await new Authenticator().Authenticate(config, username, password);
+            CaptureCredentialForPasswordChangeFlow(username, password);
 
             User user;
             try
@@ -78,6 +83,11 @@ namespace Jellyfin.Plugin.Authelia_Auth
                 user.Password = _cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
             }
 
+            if (user == null)
+            {
+                throw new AuthenticationException("User does not exist in Jellyfin and auto-create is disabled.");
+            }
+
             // Only manage admin permissions if the admin group is set in config
             if (!string.IsNullOrWhiteSpace(config.AutheliaAdminGroup))
             {
@@ -94,9 +104,129 @@ namespace Jellyfin.Plugin.Authelia_Auth
         }
 
         /// <inheritdoc />
-        public Task ChangePassword(User user, string newPassword)
+        public async Task ChangePassword(User user, string newPassword)
         {
-            throw new NotImplementedException();
+            if (string.IsNullOrWhiteSpace(newPassword))
+            {
+                throw new AuthenticationException("New password cannot be empty.");
+            }
+
+            var username = user.Username;
+            var config = AutheliaPlugin.Instance.Configuration;
+            var oldPassword = TakeCredentialForPasswordChangeFlow(username);
+
+            if (oldPassword == null)
+            {
+                throw new AuthenticationException(
+                    $"Unable to change password from Jellyfin because the current password was not provided "
+                    + $"in this password-change request. "
+                    + $"Enter your current password and retry, or change it directly in Authelia at "
+                    + $"{BuildAutheliaPortalUrl(config.AutheliaServer)}.");
+            }
+
+            try
+            {
+                await new Authenticator().ChangePassword(config, username, oldPassword, newPassword);
+            }
+            catch (AuthenticationException ex)
+            {
+                if (ex.Message.Contains("elevated session", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new AuthenticationException(
+                        $"Authelia requires an elevated session before changing passwords. "
+                        + $"Open {BuildAutheliaPortalUrl(config.AutheliaServer)} and change your password there.");
+                }
+
+                throw;
+            }
+        }
+
+        private static string BuildAutheliaPortalUrl(string server)
+        {
+            if (Uri.TryCreate(server, UriKind.Absolute, out var uri))
+            {
+                return string.IsNullOrEmpty(uri.Authority)
+                    ? server
+                    : $"{uri.Scheme}://{uri.Authority}/";
+            }
+
+            return server;
+        }
+
+        private void CaptureCredentialForPasswordChangeFlow(string username, string password)
+        {
+            if (!TryGetCurrentHttpContext(out var httpContext) || !IsPasswordChangeRoute(httpContext.Request.Path.Value ?? string.Empty))
+            {
+                return;
+            }
+
+            httpContext.Items[BuildFlowCredentialKey(username)] = password;
+        }
+
+        private string TakeCredentialForPasswordChangeFlow(string username)
+        {
+            if (!TryGetCurrentHttpContext(out var httpContext))
+            {
+                return null;
+            }
+
+            var key = BuildFlowCredentialKey(username);
+
+            if (!httpContext.Items.TryGetValue(key, out var value) || value is not string password)
+            {
+                return null;
+            }
+
+            httpContext.Items.Remove(key);
+            return password;
+        }
+
+        private bool TryGetCurrentHttpContext(out HttpContext httpContext)
+        {
+            httpContext = null;
+
+            IHttpContextAccessor accessor;
+            try
+            {
+                accessor = _applicationHost.Resolve<IHttpContextAccessor>();
+            }
+            catch
+            {
+                return false;
+            }
+
+            httpContext = accessor?.HttpContext;
+            return httpContext != null;
+        }
+
+        private static bool IsPasswordChangeRoute(string requestPath)
+        {
+            if (string.IsNullOrWhiteSpace(requestPath))
+            {
+                return false;
+            }
+
+            var segments = requestPath
+                .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            if (segments.Length < 2 || !segments[^1].Equals("Password", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (segments[^2].Equals("Users", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return segments.Length >= 3
+                && segments[^3].Equals("Users", StringComparison.OrdinalIgnoreCase)
+                && Guid.TryParse(segments[^2], out _);
+        }
+
+        private static string BuildFlowCredentialKey(string username)
+        {
+            return $"authelia-auth:password-flow:{username.ToLowerInvariant()}";
         }
     }
 }

--- a/Authelia-Auth/AutheliaAuthenticationProviderPlugin.cs
+++ b/Authelia-Auth/AutheliaAuthenticationProviderPlugin.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Security.Cryptography;
+using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
@@ -8,7 +9,6 @@ using MediaBrowser.Common;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Cryptography;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.Authelia_Auth
@@ -18,6 +18,8 @@ namespace Jellyfin.Plugin.Authelia_Auth
     /// </summary>
     public class AutheliaAuthenticationProviderPlugin : IAuthenticationProvider
     {
+        private static readonly AsyncLocal<FlowCredential> CurrentFlowCredential = new();
+
         private readonly IApplicationHost _applicationHost;
         private readonly ILogger<AutheliaAuthenticationProviderPlugin> _logger;
         private readonly ICryptoProvider _cryptoProvider;
@@ -61,7 +63,7 @@ namespace Jellyfin.Plugin.Authelia_Auth
             var config = AutheliaPlugin.Instance.Configuration;
 
             var auth = await new Authenticator().Authenticate(config, username, password);
-            CaptureCredentialForPasswordChangeFlow(username, password);
+            CurrentFlowCredential.Value = new FlowCredential(username, password);
 
             User user;
             try
@@ -113,9 +115,9 @@ namespace Jellyfin.Plugin.Authelia_Auth
 
             var username = user.Username;
             var config = AutheliaPlugin.Instance.Configuration;
-            var oldPassword = TakeCredentialForPasswordChangeFlow(username);
+            var flowCredential = CurrentFlowCredential.Value;
 
-            if (oldPassword == null)
+            if (flowCredential == null || !string.Equals(flowCredential.Username, username, StringComparison.OrdinalIgnoreCase))
             {
                 throw new AuthenticationException(
                     $"Unable to change password from Jellyfin because the current password was not provided "
@@ -124,9 +126,11 @@ namespace Jellyfin.Plugin.Authelia_Auth
                     + $"{BuildAutheliaPortalUrl(config.AutheliaServer)}.");
             }
 
+            CurrentFlowCredential.Value = null;
+
             try
             {
-                await new Authenticator().ChangePassword(config, username, oldPassword, newPassword);
+                await new Authenticator().ChangePassword(config, username, flowCredential.Password, newPassword);
             }
             catch (AuthenticationException ex)
             {
@@ -153,80 +157,17 @@ namespace Jellyfin.Plugin.Authelia_Auth
             return server;
         }
 
-        private void CaptureCredentialForPasswordChangeFlow(string username, string password)
+        private sealed class FlowCredential
         {
-            if (!TryGetCurrentHttpContext(out var httpContext) || !IsPasswordChangeRoute(httpContext.Request.Path.Value ?? string.Empty))
+            public FlowCredential(string username, string password)
             {
-                return;
+                Username = username;
+                Password = password;
             }
 
-            httpContext.Items[BuildFlowCredentialKey(username)] = password;
-        }
+            public string Username { get; }
 
-        private string TakeCredentialForPasswordChangeFlow(string username)
-        {
-            if (!TryGetCurrentHttpContext(out var httpContext))
-            {
-                return null;
-            }
-
-            var key = BuildFlowCredentialKey(username);
-
-            if (!httpContext.Items.TryGetValue(key, out var value) || value is not string password)
-            {
-                return null;
-            }
-
-            httpContext.Items.Remove(key);
-            return password;
-        }
-
-        private bool TryGetCurrentHttpContext(out HttpContext httpContext)
-        {
-            httpContext = null;
-
-            IHttpContextAccessor accessor;
-            try
-            {
-                accessor = _applicationHost.Resolve<IHttpContextAccessor>();
-            }
-            catch
-            {
-                return false;
-            }
-
-            httpContext = accessor?.HttpContext;
-            return httpContext != null;
-        }
-
-        private static bool IsPasswordChangeRoute(string requestPath)
-        {
-            if (string.IsNullOrWhiteSpace(requestPath))
-            {
-                return false;
-            }
-
-            var segments = requestPath
-                .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-            if (segments.Length < 2 || !segments[^1].Equals("Password", StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
-            if (segments[^2].Equals("Users", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            return segments.Length >= 3
-                && segments[^3].Equals("Users", StringComparison.OrdinalIgnoreCase)
-                && Guid.TryParse(segments[^2], out _);
-        }
-
-        private static string BuildFlowCredentialKey(string username)
-        {
-            return $"authelia-auth:password-flow:{username.ToLowerInvariant()}";
+            public string Password { get; }
         }
     }
 }

--- a/Authelia-Auth/AutheliaAuthenticationProviderPlugin.cs
+++ b/Authelia-Auth/AutheliaAuthenticationProviderPlugin.cs
@@ -119,6 +119,9 @@ namespace Jellyfin.Plugin.Authelia_Auth
 
             if (flowCredential == null || !string.Equals(flowCredential.Username, username, StringComparison.OrdinalIgnoreCase))
             {
+                flowCredential?.Clear();
+                CurrentFlowCredential.Value = null;
+
                 throw new AuthenticationException(
                     $"Unable to change password from Jellyfin because the current password was not provided "
                     + $"in this password-change request. "
@@ -126,22 +129,20 @@ namespace Jellyfin.Plugin.Authelia_Auth
                     + $"{BuildAutheliaPortalUrl(config.AutheliaServer)}.");
             }
 
-            CurrentFlowCredential.Value = null;
-
             try
             {
-                await new Authenticator().ChangePassword(config, username, flowCredential.Password, newPassword);
+                await new Authenticator().ChangePassword(config, username, flowCredential.GetPassword(), newPassword);
             }
-            catch (AuthenticationException ex)
+            catch (PasswordChangeElevationRequiredException)
             {
-                if (ex.Message.Contains("elevated session", StringComparison.OrdinalIgnoreCase))
-                {
-                    throw new AuthenticationException(
-                        $"Authelia requires an elevated session before changing passwords. "
-                        + $"Open {BuildAutheliaPortalUrl(config.AutheliaServer)} and change your password there.");
-                }
-
-                throw;
+                throw new AuthenticationException(
+                    $"Authelia requires an elevated session before changing passwords. "
+                    + $"Open {BuildAutheliaPortalUrl(config.AutheliaServer)} and change your password there.");
+            }
+            finally
+            {
+                flowCredential?.Clear();
+                CurrentFlowCredential.Value = null;
             }
         }
 
@@ -149,9 +150,8 @@ namespace Jellyfin.Plugin.Authelia_Auth
         {
             if (Uri.TryCreate(server, UriKind.Absolute, out var uri))
             {
-                return string.IsNullOrEmpty(uri.Authority)
-                    ? server
-                    : $"{uri.Scheme}://{uri.Authority}/";
+                var path = uri.GetLeftPart(UriPartial.Path);
+                return path.EndsWith("/", StringComparison.Ordinal) ? path : path + "/";
             }
 
             return server;
@@ -162,12 +162,26 @@ namespace Jellyfin.Plugin.Authelia_Auth
             public FlowCredential(string username, string password)
             {
                 Username = username;
-                Password = password;
+                PasswordChars = password.ToCharArray();
             }
 
             public string Username { get; }
 
-            public string Password { get; }
+            private char[] PasswordChars { get; set; }
+
+            public string GetPassword()
+            {
+                return new string(PasswordChars);
+            }
+
+            public void Clear()
+            {
+                if (PasswordChars.Length > 0)
+                {
+                    Array.Clear(PasswordChars, 0, PasswordChars.Length);
+                    PasswordChars = Array.Empty<char>();
+                }
+            }
         }
     }
 }

--- a/Authelia-Auth/Authenticator.cs
+++ b/Authelia-Auth/Authenticator.cs
@@ -129,6 +129,12 @@ namespace Jellyfin.Plugin.Authelia_Auth
         /// <exception cref="AuthenticationException">Exception when failing to change password.</exception>
         public async Task ChangePassword(PluginConfiguration config, string username, string oldPassword, string newPassword, string oneTimeCode = null)
         {
+            if (!string.IsNullOrWhiteSpace(config.PasswordChangeHelperUrl))
+            {
+                await ChangePasswordWithHelper(config, username, oldPassword, newPassword);
+                return;
+            }
+
             var cookieContainer = new CookieContainer();
             using var handler = CreateHandler(config, cookieContainer);
             using var client = new HttpClient(handler) { BaseAddress = new Uri(config.AutheliaServer) };
@@ -306,6 +312,41 @@ namespace Jellyfin.Plugin.Authelia_Auth
             using var response = await client.PutAsync("/api/user/session/elevation", content);
 
             return response.IsSuccessStatusCode;
+        }
+
+        private static async Task ChangePasswordWithHelper(PluginConfiguration config, string username, string oldPassword, string newPassword)
+        {
+            var cookieContainer = new CookieContainer();
+            using var handler = CreateHandler(config, cookieContainer);
+            using var client = new HttpClient(handler) { BaseAddress = new Uri(config.PasswordChangeHelperUrl) };
+
+            if (!string.IsNullOrWhiteSpace(config.PasswordChangeHelperToken))
+            {
+                client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", config.PasswordChangeHelperToken);
+            }
+
+            var payload = new JsonObject
+            {
+                { "username", username },
+                { "old_password", oldPassword },
+                { "new_password", newPassword }
+            };
+
+            using var content = new StringContent(payload.ToString(), Encoding.UTF8, "application/json");
+            using var response = await client.PostAsync("/change-password", content);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return;
+            }
+
+            var errorBody = await response.Content.ReadAsStringAsync();
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                throw new AuthenticationException(MessageInvalidCredentials);
+            }
+
+            throw new AuthenticationException($"Password change helper failed (HTTP {(int)response.StatusCode}): {TruncateForMessage(errorBody)}");
         }
 
         private static async Task<bool> TryStartElevationCodeFlow(HttpClient client)

--- a/Authelia-Auth/Authenticator.cs
+++ b/Authelia-Auth/Authenticator.cs
@@ -26,6 +26,15 @@ namespace Jellyfin.Plugin.Authelia_Auth
             : base("Authelia requires an elevated session to change passwords.")
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordChangeElevationRequiredException"/> class.
+        /// </summary>
+        /// <param name="message">Exception message.</param>
+        public PasswordChangeElevationRequiredException(string message)
+            : base(message)
+        {
+        }
     }
 
     /// <summary>
@@ -115,9 +124,10 @@ namespace Jellyfin.Plugin.Authelia_Auth
         /// <param name="username">Username to authenticate.</param>
         /// <param name="oldPassword">Current password.</param>
         /// <param name="newPassword">New password.</param>
+        /// <param name="oneTimeCode">Optional one-time code from Authelia elevation flow.</param>
         /// <returns>A <see cref="Task"/> representing asynchronous operation.</returns>
         /// <exception cref="AuthenticationException">Exception when failing to change password.</exception>
-        public async Task ChangePassword(PluginConfiguration config, string username, string oldPassword, string newPassword)
+        public async Task ChangePassword(PluginConfiguration config, string username, string oldPassword, string newPassword, string oneTimeCode = null)
         {
             var cookieContainer = new CookieContainer();
             using var handler = CreateHandler(config, cookieContainer);
@@ -148,6 +158,47 @@ namespace Jellyfin.Plugin.Authelia_Auth
 
             if (response.StatusCode == HttpStatusCode.Forbidden && IsElevationRequired(errorBody))
             {
+                var hasOneTimeCode = !string.IsNullOrWhiteSpace(oneTimeCode);
+
+                var elevatedByOneTimeCode = await TryElevateSessionWithOneTimeCode(client, oneTimeCode);
+                if (elevatedByOneTimeCode)
+                {
+                    using var retryContent = new StringContent(payload.ToString(), Encoding.UTF8, "application/json");
+                    using var retryResponse = await client.PostAsync("/api/change-password", retryContent);
+
+                    if (retryResponse.IsSuccessStatusCode)
+                    {
+                        return;
+                    }
+
+                    if (retryResponse.StatusCode == HttpStatusCode.Unauthorized)
+                    {
+                        throw new AuthenticationException(MessageInvalidCredentials);
+                    }
+
+                    var retryErrorBody = await retryResponse.Content.ReadAsStringAsync();
+                    if (retryResponse.StatusCode == HttpStatusCode.Forbidden && IsElevationRequired(retryErrorBody))
+                    {
+                        throw new PasswordChangeElevationRequiredException(
+                            "Authelia elevation code was accepted, but password change still requires elevation. Request a new code and retry.");
+                    }
+
+                    throw new AuthenticationException($"Authelia failed to change the password after one-time code elevation attempt (HTTP {(int)retryResponse.StatusCode}): {TruncateForMessage(retryErrorBody)}");
+                }
+
+                if (hasOneTimeCode)
+                {
+                    throw new PasswordChangeElevationRequiredException(
+                        "The provided Authelia elevation code was invalid or expired. Request a new code and retry with currentPassword::otc=YOURCODE.");
+                }
+
+                var elevationCodeRequested = await TryStartElevationCodeFlow(client);
+                if (elevationCodeRequested)
+                {
+                    throw new PasswordChangeElevationRequiredException(
+                        "Authelia requires elevation before password change. A one-time code request was created. Check your email and retry with currentPassword::otc=YOURCODE.");
+                }
+
                 var elevated = await TryElevateSessionWithPassword(client, config, oldPassword);
                 if (elevated)
                 {
@@ -167,14 +218,18 @@ namespace Jellyfin.Plugin.Authelia_Auth
                     var retryErrorBody = await retryResponse.Content.ReadAsStringAsync();
                     if (retryResponse.StatusCode == HttpStatusCode.Forbidden && IsElevationRequired(retryErrorBody))
                     {
-                        throw new PasswordChangeElevationRequiredException();
+                        throw new PasswordChangeElevationRequiredException(
+                            "Authelia requires elevation before password change. Request a code in the Authelia portal and retry with currentPassword::otc=YOURCODE.");
                     }
+
+                    throw new AuthenticationException($"Authelia failed to change the password after elevation attempt (HTTP {(int)retryResponse.StatusCode}): {TruncateForMessage(retryErrorBody)}");
                 }
 
-                throw new PasswordChangeElevationRequiredException();
+                throw new PasswordChangeElevationRequiredException(
+                    "Authelia requires elevation before password change. Request a code in the Authelia portal and retry with currentPassword::otc=YOURCODE.");
             }
 
-            throw new AuthenticationException("Authelia failed to change the password.");
+            throw new AuthenticationException($"Authelia failed to change the password (HTTP {(int)response.StatusCode}): {TruncateForMessage(errorBody)}");
         }
 
         private static HttpClientHandler CreateHandler(PluginConfiguration config, CookieContainer cookieContainer)
@@ -235,6 +290,32 @@ namespace Jellyfin.Plugin.Authelia_Auth
             }
         }
 
+        private static async Task<bool> TryElevateSessionWithOneTimeCode(HttpClient client, string oneTimeCode)
+        {
+            if (string.IsNullOrWhiteSpace(oneTimeCode))
+            {
+                return false;
+            }
+
+            var jsonBody = new JsonObject
+            {
+                { "otc", oneTimeCode.Trim().ToUpperInvariant() }
+            };
+
+            using var content = new StringContent(jsonBody.ToString(), Encoding.UTF8, "application/json");
+            using var response = await client.PutAsync("/api/user/session/elevation", content);
+
+            return response.IsSuccessStatusCode;
+        }
+
+        private static async Task<bool> TryStartElevationCodeFlow(HttpClient client)
+        {
+            using var content = new StringContent("{}", Encoding.UTF8, "application/json");
+            using var response = await client.PostAsync("/api/user/session/elevation", content);
+
+            return response.IsSuccessStatusCode;
+        }
+
         private static async Task<bool> TryElevateSessionWithPassword(HttpClient client, PluginConfiguration config, string password)
         {
             var jsonBody = new JsonObject
@@ -281,15 +362,21 @@ namespace Jellyfin.Plugin.Authelia_Auth
                 return false;
             }
 
-            if (!TryGetBoolean(dataObject, "first_factor", out var hasFirstFactor) || !hasFirstFactor)
-            {
-                return false;
-            }
-
             var hasElevation = TryGetBoolean(dataObject, "elevation", out var elevation);
             var hasSecondFactor = TryGetBoolean(dataObject, "second_factor", out var secondFactor);
+            var hasFirstFactor = TryGetBoolean(dataObject, "first_factor", out var firstFactor);
 
             if (hasElevation && !elevation)
+            {
+                return true;
+            }
+
+            if (hasElevation && elevation)
+            {
+                return true;
+            }
+
+            if (hasFirstFactor && !firstFactor)
             {
                 return true;
             }
@@ -320,6 +407,18 @@ namespace Jellyfin.Plugin.Authelia_Auth
             {
                 return false;
             }
+        }
+
+        private static string TruncateForMessage(string content)
+        {
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return "<empty>";
+            }
+
+            var trimmed = content.Trim();
+            const int maxLength = 280;
+            return trimmed.Length <= maxLength ? trimmed : trimmed.Substring(0, maxLength) + "...";
         }
     }
 }

--- a/Authelia-Auth/Authenticator.cs
+++ b/Authelia-Auth/Authenticator.cs
@@ -148,6 +148,29 @@ namespace Jellyfin.Plugin.Authelia_Auth
 
             if (response.StatusCode == HttpStatusCode.Forbidden && IsElevationRequired(errorBody))
             {
+                var elevated = await TryElevateSessionWithPassword(client, config, oldPassword);
+                if (elevated)
+                {
+                    using var retryContent = new StringContent(payload.ToString(), Encoding.UTF8, "application/json");
+                    using var retryResponse = await client.PostAsync("/api/change-password", retryContent);
+
+                    if (retryResponse.IsSuccessStatusCode)
+                    {
+                        return;
+                    }
+
+                    if (retryResponse.StatusCode == HttpStatusCode.Unauthorized)
+                    {
+                        throw new AuthenticationException(MessageInvalidCredentials);
+                    }
+
+                    var retryErrorBody = await retryResponse.Content.ReadAsStringAsync();
+                    if (retryResponse.StatusCode == HttpStatusCode.Forbidden && IsElevationRequired(retryErrorBody))
+                    {
+                        throw new PasswordChangeElevationRequiredException();
+                    }
+                }
+
                 throw new PasswordChangeElevationRequiredException();
             }
 
@@ -212,6 +235,20 @@ namespace Jellyfin.Plugin.Authelia_Auth
             }
         }
 
+        private static async Task<bool> TryElevateSessionWithPassword(HttpClient client, PluginConfiguration config, string password)
+        {
+            var jsonBody = new JsonObject
+            {
+                { "password", password },
+                { "targetURL", config.JellyfinUrl }
+            };
+
+            using var content = new StringContent(jsonBody.ToString(), Encoding.UTF8, "application/json");
+            using var response = await client.PostAsync("/api/secondfactor/password", content);
+
+            return response.IsSuccessStatusCode;
+        }
+
         private static bool IsElevationRequired(string errorBody)
         {
             if (string.IsNullOrWhiteSpace(errorBody))
@@ -244,19 +281,45 @@ namespace Jellyfin.Plugin.Authelia_Auth
                 return false;
             }
 
-            if (elevationNode is JsonValue jsonValue)
+            if (!TryGetBoolean(dataObject, "first_factor", out var hasFirstFactor) || !hasFirstFactor)
             {
-                try
-                {
-                    return jsonValue.GetValue<bool>();
-                }
-                catch
-                {
-                    return false;
-                }
+                return false;
+            }
+
+            var hasElevation = TryGetBoolean(dataObject, "elevation", out var elevation);
+            var hasSecondFactor = TryGetBoolean(dataObject, "second_factor", out var secondFactor);
+
+            if (hasElevation && !elevation)
+            {
+                return true;
+            }
+
+            if (hasSecondFactor && !secondFactor)
+            {
+                return true;
             }
 
             return false;
+        }
+
+        private static bool TryGetBoolean(JsonObject jsonObject, string propertyName, out bool value)
+        {
+            value = false;
+
+            if (!jsonObject.TryGetPropertyValue(propertyName, out var node) || node is not JsonValue jsonValue)
+            {
+                return false;
+            }
+
+            try
+            {
+                value = jsonValue.GetValue<bool>();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 }

--- a/Authelia-Auth/Authenticator.cs
+++ b/Authelia-Auth/Authenticator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json.Nodes;
@@ -13,6 +14,20 @@ namespace Jellyfin.Plugin.Authelia_Auth
 {
 #pragma warning disable SA1649
 #pragma warning disable SA1402
+    /// <summary>
+    /// Indicates Authelia requires elevation before password change.
+    /// </summary>
+    public sealed class PasswordChangeElevationRequiredException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PasswordChangeElevationRequiredException"/> class.
+        /// </summary>
+        public PasswordChangeElevationRequiredException()
+            : base("Authelia requires an elevated session to change passwords.")
+        {
+        }
+    }
+
     /// <summary>
     /// AutheliaUser is ProviderAuthenticationResult enriched with group information.
     /// </summary>
@@ -58,7 +73,7 @@ namespace Jellyfin.Plugin.Authelia_Auth
             {
                 request.Headers.Add("X-Original-URL", config.JellyfinUrl);
                 request.Headers.Add("X-Original-Method", "GET");
-                var accessResponse = await client.SendAsync(request);
+                using var accessResponse = await client.SendAsync(request);
                 if (!accessResponse.IsSuccessStatusCode)
                 {
                     throw new AuthenticationException("User doesn't have access to this service.");
@@ -117,7 +132,7 @@ namespace Jellyfin.Plugin.Authelia_Auth
             };
 
             using var content = new StringContent(payload.ToString(), Encoding.UTF8, "application/json");
-            var response = await client.PostAsync("/api/change-password", content);
+            using var response = await client.PostAsync("/api/change-password", content);
 
             if (response.IsSuccessStatusCode)
             {
@@ -133,7 +148,7 @@ namespace Jellyfin.Plugin.Authelia_Auth
 
             if (response.StatusCode == HttpStatusCode.Forbidden && IsElevationRequired(errorBody))
             {
-                throw new AuthenticationException("Authelia requires an elevated session to change passwords.");
+                throw new PasswordChangeElevationRequiredException();
             }
 
             throw new AuthenticationException("Authelia failed to change the password.");
@@ -144,17 +159,37 @@ namespace Jellyfin.Plugin.Authelia_Auth
             return new HttpClientHandler()
             {
                 CookieContainer = cookieContainer,
-                ServerCertificateCustomValidationCallback = (message, cert, chain, _) =>
+                ServerCertificateCustomValidationCallback = (message, cert, chain, sslPolicyErrors) =>
                 {
-                    if (!string.IsNullOrWhiteSpace(config.AutheliaRootCa))
-                    {
-                        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                        chain.ChainPolicy.CustomTrustStore.ImportFromPem(config.AutheliaRootCa);
-                    }
-
-                    return chain.Build(cert);
+                    return ValidateServerCertificate(config, cert as X509Certificate2, chain, sslPolicyErrors);
                 }
             };
+        }
+
+        private static bool ValidateServerCertificate(PluginConfiguration config, X509Certificate2 cert, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+        {
+            if (cert == null)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(config.AutheliaRootCa))
+            {
+                return sslPolicyErrors == SslPolicyErrors.None;
+            }
+
+            using var validationChain = chain ?? new X509Chain();
+
+            validationChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+            validationChain.ChainPolicy.CustomTrustStore.Clear();
+            validationChain.ChainPolicy.CustomTrustStore.ImportFromPem(config.AutheliaRootCa);
+            if (!validationChain.Build(cert))
+            {
+                return false;
+            }
+
+            var disallowedErrors = sslPolicyErrors & ~SslPolicyErrors.RemoteCertificateChainErrors;
+            return disallowedErrors == SslPolicyErrors.None;
         }
 
         private static async Task AuthenticateFirstFactor(HttpClient client, PluginConfiguration config, string username, string password)
@@ -169,7 +204,7 @@ namespace Jellyfin.Plugin.Authelia_Auth
             };
 
             using var content = new StringContent(jsonBody.ToString(), Encoding.UTF8, "application/json");
-            var response = await client.PostAsync("/api/firstfactor", content);
+            using var response = await client.PostAsync("/api/firstfactor", content);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -194,7 +229,34 @@ namespace Jellyfin.Plugin.Authelia_Auth
                 return false;
             }
 
-            return root?["data"]?["elevation"]?.GetValue<bool>() == true;
+            if (root is not JsonObject rootObject)
+            {
+                return false;
+            }
+
+            if (!rootObject.TryGetPropertyValue("data", out var dataNode) || dataNode is not JsonObject dataObject)
+            {
+                return false;
+            }
+
+            if (!dataObject.TryGetPropertyValue("elevation", out var elevationNode) || elevationNode is null)
+            {
+                return false;
+            }
+
+            if (elevationNode is JsonValue jsonValue)
+            {
+                try
+                {
+                    return jsonValue.GetValue<bool>();
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/Authelia-Auth/Authenticator.cs
+++ b/Authelia-Auth/Authenticator.cs
@@ -36,6 +36,8 @@ namespace Jellyfin.Plugin.Authelia_Auth
     /// </summary>
     public class Authenticator
     {
+        private const string MessageInvalidCredentials = "Invalid username or password.";
+
         /// <summary>
         /// Authenticate user.
         /// </summary>
@@ -47,40 +49,10 @@ namespace Jellyfin.Plugin.Authelia_Auth
         public async Task<AutheliaUser> Authenticate(PluginConfiguration config, string username, string password)
         {
             var cookieContainer = new CookieContainer();
-            using var handler = new HttpClientHandler()
-            {
-                CookieContainer = cookieContainer,
-                ServerCertificateCustomValidationCallback = (message, cert, chain, _) =>
-                {
-                    if (!string.IsNullOrWhiteSpace(config.AutheliaRootCa))
-                    {
-                        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                        chain.ChainPolicy.CustomTrustStore.ImportFromPem(config.AutheliaRootCa);
-                    }
-
-                    return chain.Build(cert);
-                }
-            };
+            using var handler = CreateHandler(config, cookieContainer);
             using var client = new HttpClient(handler) { BaseAddress = new Uri(config.AutheliaServer) };
 
-            var jsonBody = new JsonObject
-                {
-                    { "username", username },
-                    { "password", password },
-                    { "targetURL", config.JellyfinUrl },
-                    { "requestMethod", "GET" },
-                    { "keepMeLoggedIn", true }
-                };
-
-            using (var content = new StringContent(jsonBody.ToString(), Encoding.UTF8, "application/json"))
-            {
-                var response = await client.PostAsync("/api/firstfactor", content);
-
-                if (!response.IsSuccessStatusCode)
-                {
-                    throw new AuthenticationException("Invalid username or password.");
-                }
-            }
+            await AuthenticateFirstFactor(client, config, username, password);
 
             using (var request = new HttpRequestMessage(HttpMethod.Get, "/api/authz/auth-request"))
             {
@@ -119,6 +91,110 @@ namespace Jellyfin.Plugin.Authelia_Auth
                     IsAdmin = isAdmin
                 };
             }
+        }
+
+        /// <summary>
+        /// Change user password.
+        /// </summary>
+        /// <param name="config">Plugin configuration.</param>
+        /// <param name="username">Username to authenticate.</param>
+        /// <param name="oldPassword">Current password.</param>
+        /// <param name="newPassword">New password.</param>
+        /// <returns>A <see cref="Task"/> representing asynchronous operation.</returns>
+        /// <exception cref="AuthenticationException">Exception when failing to change password.</exception>
+        public async Task ChangePassword(PluginConfiguration config, string username, string oldPassword, string newPassword)
+        {
+            var cookieContainer = new CookieContainer();
+            using var handler = CreateHandler(config, cookieContainer);
+            using var client = new HttpClient(handler) { BaseAddress = new Uri(config.AutheliaServer) };
+
+            await AuthenticateFirstFactor(client, config, username, oldPassword);
+
+            var payload = new JsonObject
+            {
+                { "old_password", oldPassword },
+                { "new_password", newPassword }
+            };
+
+            using var content = new StringContent(payload.ToString(), Encoding.UTF8, "application/json");
+            var response = await client.PostAsync("/api/change-password", content);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return;
+            }
+
+            var errorBody = await response.Content.ReadAsStringAsync();
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                throw new AuthenticationException(MessageInvalidCredentials);
+            }
+
+            if (response.StatusCode == HttpStatusCode.Forbidden && IsElevationRequired(errorBody))
+            {
+                throw new AuthenticationException("Authelia requires an elevated session to change passwords.");
+            }
+
+            throw new AuthenticationException("Authelia failed to change the password.");
+        }
+
+        private static HttpClientHandler CreateHandler(PluginConfiguration config, CookieContainer cookieContainer)
+        {
+            return new HttpClientHandler()
+            {
+                CookieContainer = cookieContainer,
+                ServerCertificateCustomValidationCallback = (message, cert, chain, _) =>
+                {
+                    if (!string.IsNullOrWhiteSpace(config.AutheliaRootCa))
+                    {
+                        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                        chain.ChainPolicy.CustomTrustStore.ImportFromPem(config.AutheliaRootCa);
+                    }
+
+                    return chain.Build(cert);
+                }
+            };
+        }
+
+        private static async Task AuthenticateFirstFactor(HttpClient client, PluginConfiguration config, string username, string password)
+        {
+            var jsonBody = new JsonObject
+            {
+                { "username", username },
+                { "password", password },
+                { "targetURL", config.JellyfinUrl },
+                { "requestMethod", "GET" },
+                { "keepMeLoggedIn", true }
+            };
+
+            using var content = new StringContent(jsonBody.ToString(), Encoding.UTF8, "application/json");
+            var response = await client.PostAsync("/api/firstfactor", content);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new AuthenticationException(MessageInvalidCredentials);
+            }
+        }
+
+        private static bool IsElevationRequired(string errorBody)
+        {
+            if (string.IsNullOrWhiteSpace(errorBody))
+            {
+                return false;
+            }
+
+            JsonNode root;
+            try
+            {
+                root = JsonNode.Parse(errorBody);
+            }
+            catch
+            {
+                return false;
+            }
+
+            return root?["data"]?["elevation"]?.GetValue<bool>() == true;
         }
     }
 }

--- a/Authelia-Auth/Config/PluginConfiguration.cs
+++ b/Authelia-Auth/Config/PluginConfiguration.cs
@@ -16,6 +16,8 @@ namespace Jellyfin.Plugin.Authelia_Auth.Config
             JellyfinUrl = "http://jellyfin";
             AutheliaRootCa = string.Empty;
             AutheliaAdminGroup = string.Empty;
+            PasswordChangeHelperUrl = string.Empty;
+            PasswordChangeHelperToken = string.Empty;
             CreateUserIfNotExists = true;
         }
 
@@ -43,5 +45,15 @@ namespace Jellyfin.Plugin.Authelia_Auth.Config
         /// Gets or sets the jellyfin URL.
         /// </summary>
         public string JellyfinUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional password change helper URL.
+        /// </summary>
+        public string PasswordChangeHelperUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional password change helper bearer token.
+        /// </summary>
+        public string PasswordChangeHelperToken { get; set; }
     }
 }

--- a/Authelia-Auth/Config/configPage.html
+++ b/Authelia-Auth/Config/configPage.html
@@ -86,6 +86,24 @@
                                     />
                                     <div class="fieldDescription">The external url of jellyfin used by Authelia for authentication rules.</div>
                                 </div>
+                                <div class="inputContainer">
+                                    <input
+                                        is="emby-input"
+                                        type="text"
+                                        id="PasswordChangeHelperUrl"
+                                        label="Password change helper URL (optional):"
+                                    />
+                                    <div class="fieldDescription">Optional homelab/file-backend helper endpoint, for example http://192.168.20.4:9944. Leave empty to use Authelia's native password-change API.</div>
+                                </div>
+                                <div class="inputContainer">
+                                    <input
+                                        is="emby-input"
+                                        type="password"
+                                        id="PasswordChangeHelperToken"
+                                        label="Password change helper bearer token (optional):"
+                                    />
+                                    <div class="fieldDescription">Shared secret for the optional password change helper. Required if the helper enforces bearer authentication.</div>
+                                </div>
                             </div>
                         </div>
                         <div>
@@ -144,6 +162,8 @@
                     CreateUserIfNotExists: document.querySelector("#CreateUserIfNotExists"),
                     AutheliaAdminGroup: document.querySelector("#AutheliaAdminGroup"),
                     JellyfinUrl: document.querySelector("#JellyfinUrl"),
+                    PasswordChangeHelperUrl: document.querySelector("#PasswordChangeHelperUrl"),
+                    PasswordChangeHelperToken: document.querySelector("#PasswordChangeHelperToken"),
                 };
 
                 document.querySelector(".esqConfigurationPage").addEventListener("pageshow", function () {
@@ -153,6 +173,8 @@
                         AutheliaConfigurationPage.CreateUserIfNotExists.checked = config.CreateUserIfNotExists;
                         AutheliaConfigurationPage.AutheliaAdminGroup.value = config.AutheliaAdminGroup;
                         AutheliaConfigurationPage.JellyfinUrl.value = config.JellyfinUrl;
+                        AutheliaConfigurationPage.PasswordChangeHelperUrl.value = config.PasswordChangeHelperUrl || "";
+                        AutheliaConfigurationPage.PasswordChangeHelperToken.value = config.PasswordChangeHelperToken || "";
 
                         AutheliaConfigurationPage.AutheliaRootCa.placeholder = AutheliaConfigurationPage.AutheliaRootCa.placeholder.replace(/\\n/g, "\n");
                     });
@@ -169,6 +191,8 @@
                         config.CreateUserIfNotExists = AutheliaConfigurationPage.CreateUserIfNotExists.checked;
                         config.AutheliaAdminGroup = AutheliaConfigurationPage.AutheliaAdminGroup.value;
                         config.JellyfinUrl = AutheliaConfigurationPage.JellyfinUrl.value;
+                        config.PasswordChangeHelperUrl = AutheliaConfigurationPage.PasswordChangeHelperUrl.value;
+                        config.PasswordChangeHelperToken = AutheliaConfigurationPage.PasswordChangeHelperToken.value;
                         window.ApiClient.updatePluginConfiguration(AutheliaConfigurationPage.pluginUniqueId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                     });
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,40 @@ The plugin will automatically create a new Jellyfin user upon successful authent
 
 ## Password changes
 
-This fork adds best-effort support for native Jellyfin password changes for Authelia-backed users:
+This fork adds support for native Jellyfin password changes for Authelia-backed users.
 
-- The user must first successfully authenticate in Jellyfin with their current password.
-- The plugin then calls `POST /api/change-password` on Authelia with `old_password` and `new_password`.
-- If Authelia requires an elevated session for password changes, Jellyfin shows an actionable error and users must change the password directly in the Authelia portal.
+### Jellyfin <-> Authelia flow
 
-Technical note: Jellyfin's `IAuthenticationProvider.ChangePassword` does not include the current password. This fork bridges this by carrying credentials only in the same execution flow (in-memory `AsyncLocal` handoff), then immediately consuming them for the Authelia password-change call.
+1. Jellyfin validates `CurrentPw` by calling plugin `Authenticate(username, currentPassword)`.
+2. In that same request flow, the plugin captures request-scoped credentials (in-memory only).
+3. Jellyfin then calls plugin `ChangePassword(user, newPassword)`.
+4. Plugin reuses the captured current password and calls Authelia:
+   - `POST /api/firstfactor`
+   - `POST /api/change-password` with `old_password` + `new_password`
+5. If Authelia requires elevation, plugin starts elevation challenge and asks user to retry with one-time code.
+
+### Elevation one-time code retry
+
+When Authelia requires elevated session, retry password change in Jellyfin with this format in the **Current Password** field:
+
+`currentPassword::otc=YOURCODE`
+
+The plugin will:
+- split `currentPassword` and `otc`
+- call `PUT /api/user/session/elevation` with `{"otc":"YOURCODE"}`
+- retry `POST /api/change-password`
+
+### Important limitations
+
+- Jellyfin API does not expose a separate OTC field; this fork uses `::otc=` marker in the current password field.
+- Credentials and OTC are request-scoped and ephemeral (not persisted intentionally).
+- 2FA login itself is still not supported by this plugin (same as upstream design).
+
+### Security considerations
+
+- Passwords are transmitted to Authelia in JSON request bodies (`old_password`, `new_password`) as required by Authelia API.
+- **Use HTTPS between Jellyfin and Authelia.** If `http://` is used on a shared network segment, credentials can be intercepted in transit.
+- Avoid debug logging of raw credentials in reverse proxies, middleware, or packet captures.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,60 @@ The main drawback of this approach is that only username+password authentication
 
 The plugin will automatically create a new Jellyfin user upon successful authentication. Any valid Authelia user can log in to Jellyfin.
 
+## Quick setup (easy)
+
+### 1) Install plugin in Jellyfin
+
+1. Go to **Dashboard -> Plugins -> Repositories**.
+2. Add repository URL:
+   - `https://raw.githubusercontent.com/nikarh/jellyfin-plugin-authelia/main/manifest.json`
+3. Open **Catalog**, install **Authelia Authentication**.
+4. Restart Jellyfin.
+
+### 2) Configure plugin
+
+Go to **Dashboard -> Plugins -> My Plugins -> Authelia Authentication** and fill:
+
+- **Authelia Server**: your Authelia base URL, e.g. `https://auth.example.com`
+- **Jellyfin Url**: the public URL users use for Jellyfin, e.g. `https://jellyfin-app.example.com`
+- **Create a new user on successful login**: usually `enabled`
+- **Authelia admin group name** (optional): e.g. `jellyfin-admins`
+
+Then click **Save**.
+
+> Note: this plugin does **not** use an Authelia API key.
+> Authentication is done with each user's own username/password via Authelia HTTP endpoints.
+
+### 3) Configure Authelia access rules
+
+Make sure your Jellyfin app domain is allowed in Authelia access control, for example:
+
+```yaml
+access_control:
+  rules:
+    - domain: jellyfin-app.example.com
+      policy: one_factor
+      subject:
+        - group:jellyfin-users
+```
+
+If you define `server.endpoints.authz`, ensure `auth-request` remains enabled:
+
+```yaml
+server:
+  endpoints:
+    authz:
+      auth-request:
+        implementation: 'AuthRequest'
+```
+
+### 4) Test login
+
+Open Jellyfin, log in with an Authelia user that matches your access rule.
+
+- If user auto-create is enabled, first successful login creates the Jellyfin user.
+- If login fails with `403` in Authelia logs, usually the access-control rule (domain/subject/policy) is the cause.
+
 ## Password changes
 
 This fork adds support for native Jellyfin password changes for Authelia-backed users.
@@ -53,6 +107,17 @@ The plugin will:
 - Passwords are transmitted to Authelia in JSON request bodies (`old_password`, `new_password`) as required by Authelia API.
 - **Use HTTPS between Jellyfin and Authelia.** If `http://` is used on a shared network segment, credentials can be intercepted in transit.
 - Avoid debug logging of raw credentials in reverse proxies, middleware, or packet captures.
+
+### Password-change UX note
+
+When Authelia requires elevation, Jellyfin currently has no dedicated OTC input field.
+Use the **Current Password** field format:
+
+`currentPassword::otc=YOURCODE`
+
+Example:
+
+`MyCurrentSecret123::otc=AB12CD34`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This fork adds best-effort support for native Jellyfin password changes for Auth
 - The plugin then calls `POST /api/change-password` on Authelia with `old_password` and `new_password`.
 - If Authelia requires an elevated session for password changes, Jellyfin shows an actionable error and users must change the password directly in the Authelia portal.
 
-Technical note: Jellyfin's `IAuthenticationProvider.ChangePassword` does not include the current password. This fork bridges this by carrying credentials only in the same request flow (request-scoped in-memory handoff), then immediately consuming them for the Authelia password-change call.
+Technical note: Jellyfin's `IAuthenticationProvider.ChangePassword` does not include the current password. This fork bridges this by carrying credentials only in the same execution flow (in-memory `AsyncLocal` handoff), then immediately consuming them for the Authelia password-change call.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ The main drawback of this approach is that only username+password authentication
 
 The plugin will automatically create a new Jellyfin user upon successful authentication. Any valid Authelia user can log in to Jellyfin.
 
+## Password changes
+
+This fork adds best-effort support for native Jellyfin password changes for Authelia-backed users:
+
+- The user must first successfully authenticate in Jellyfin with their current password.
+- The plugin then calls `POST /api/change-password` on Authelia with `old_password` and `new_password`.
+- If Authelia requires an elevated session for password changes, Jellyfin shows an actionable error and users must change the password directly in the Authelia portal.
+
+Technical note: Jellyfin's `IAuthenticationProvider.ChangePassword` does not include the current password. This fork bridges this by carrying credentials only in the same request flow (request-scoped in-memory handoff), then immediately consuming them for the Authelia password-change call.
+
 ## Usage
 
 1. Add `https://raw.githubusercontent.com/nikarh/jellyfin-plugin-authelia/main/manifest.json` as a new Jellyfin plugin repository

--- a/README.md
+++ b/README.md
@@ -109,6 +109,23 @@ The plugin will:
 - 2FA login itself is still not supported by this plugin (same as upstream design).
 - A fully user-friendly password-change UX likely requires changes in Jellyfin Web or directing users to Authelia's own portal.
 
+### Optional file-backend helper workaround
+
+For homelab setups using Authelia's file backend without deliverable user email, this fork also supports an optional external password-change helper URL.
+The helper is **not** part of Authelia and should be treated as a privileged workaround:
+
+1. Jellyfin still verifies the user's current password through the normal plugin flow.
+2. The plugin sends username/current/new password to the configured helper.
+3. The helper verifies the current password against Authelia, updates `users_database.yml`, and restarts Authelia.
+
+Security requirements:
+
+- bind the helper to a private address only
+- protect it with a strong bearer token
+- firewall it so only Jellyfin can reach it
+- never expose it to the Internet
+- only use it with Authelia file backend setups you administer
+
 ### Security considerations
 
 - Passwords are transmitted to Authelia in JSON request bodies (`old_password`, `new_password`) as required by Authelia API.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ Open Jellyfin, log in with an Authelia user that matches your access rule.
 
 ## Password changes
 
-This fork adds support for native Jellyfin password changes for Authelia-backed users.
+This fork contains experimental support for native Jellyfin password changes for Authelia-backed users.
+
+> Important: Authelia protects password changes with **Elevated Session** identity validation.
+> For users who have not completed a second factor in Authelia, this usually means Authelia sends a One-Time Code to the user's configured email address.
+> If your users have placeholder emails (for example `user@example.com`) or no working notifier, native Jellyfin password changes will not be user-friendly.
 
 ### Jellyfin <-> Authelia flow
 
@@ -87,7 +91,8 @@ This fork adds support for native Jellyfin password changes for Authelia-backed 
 
 ### Elevation one-time code retry
 
-When Authelia requires elevated session, retry password change in Jellyfin with this format in the **Current Password** field:
+When Authelia requires elevated session, Authelia sends a One-Time Code to the user's configured email address.
+Retry password change in Jellyfin with this format in the **Current Password** field:
 
 `currentPassword::otc=YOURCODE`
 
@@ -98,9 +103,11 @@ The plugin will:
 
 ### Important limitations
 
+- 1FA-only users generally still need email One-Time Code elevation for password changes; their normal password alone is not enough.
 - Jellyfin API does not expose a separate OTC field; this fork uses `::otc=` marker in the current password field.
 - Credentials and OTC are request-scoped and ephemeral (not persisted intentionally).
 - 2FA login itself is still not supported by this plugin (same as upstream design).
+- A fully user-friendly password-change UX likely requires changes in Jellyfin Web or directing users to Authelia's own portal.
 
 ### Security considerations
 

--- a/build.yaml
+++ b/build.yaml
@@ -17,6 +17,7 @@ artifacts:
 changelog: |2-
   ### Added
   - Best-effort password change support via Authelia `/api/change-password`
+  - Elevation retry support with one-time code via `currentPassword::otc=YOURCODE`
   - Dynamic fallback message to Authelia portal when elevated session is required
 
   ### Changed

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 name: "Authelia Authentication"
 guid: "6bb8dbba-2aaa-4b19-9da4-f3bbb6c44091"
 imageUrl: "https://raw.githubusercontent.com/nikarh/jellyfin-plugin-authelia/master/logo.png"
-version: "16"
+version: "17"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 owner: "nikarh"
@@ -15,5 +15,9 @@ category: "Administration"
 artifacts:
   - "Authelia-Auth.dll"
 changelog: |2-
+  ### Added
+  - Best-effort password change support via Authelia `/api/change-password`
+  - Dynamic fallback message to Authelia portal when elevated session is required
+
   ### Changed
-  - Updated for Jellyfin 10.11
+  - Refactored authentication HTTP flow for reuse between login and password change

--- a/examples/file-backend-password-helper/README.md
+++ b/examples/file-backend-password-helper/README.md
@@ -1,0 +1,82 @@
+# Authelia file-backend password helper
+
+This optional helper is a pragmatic workaround for homelab Authelia **file backend** setups where users do not have deliverable email addresses for Authelia Elevated Session One-Time Codes.
+
+It lets the Jellyfin plugin change a user's Authelia password without using Authelia's `/api/change-password` endpoint.
+
+## Flow
+
+1. User opens Jellyfin's normal password change dialog.
+2. Jellyfin verifies the current password using this plugin.
+3. Plugin calls the helper with `username`, `old_password`, and `new_password`.
+4. Helper verifies `old_password` against Authelia `/api/firstfactor`.
+5. Helper writes a new Argon2id hash to `users_database.yml`.
+6. Helper restarts Authelia so the file backend reloads.
+
+Only the password hash is changed. Groups, email, TOTP, WebAuthn, Duo, and other Authelia DB records are not modified.
+
+## Security model
+
+This helper is privileged. It can change Authelia file-backend passwords.
+
+Use **all** of these protections:
+
+- bind to a private address only
+- set a strong `HELPER_TOKEN`
+- restrict `ALLOWED_CLIENTS` to Jellyfin's IP or subnet
+- firewall the port so only Jellyfin can connect
+- never expose this helper directly to the Internet
+- use HTTPS or an isolated private network if traffic can be observed
+
+The bearer token is a shared secret. Jellyfin sends it as:
+
+```text
+Authorization: Bearer YOUR_TOKEN
+```
+
+The plugin stores the same value in **Password change helper bearer token**.
+
+## Install
+
+Run on the Authelia host/container host:
+
+```bash
+sudo HELPER_TOKEN='replace-with-long-random-secret' \
+  BIND_HOST='0.0.0.0' \
+  PORT='9944' \
+  ALLOWED_CLIENTS='192.168.20.51' \
+  AUTHELIA_BASE='https://auth.example.com' \
+  TARGET_URL='https://jellyfin-app.example.com/' \
+  USERS_DB='/opt/authelia/config/users_database.yml' \
+  AUTHELIA_CONTAINER='authelia' \
+  ./install.sh
+```
+
+If `HELPER_TOKEN` is omitted, `install.sh` generates one and prints it once.
+
+## Jellyfin plugin config
+
+Set:
+
+- **Password change helper URL**: `http://AUTHELIA_PRIVATE_IP:9944`
+- **Password change helper bearer token**: same token as `HELPER_TOKEN`
+
+Leave these fields empty to use Authelia's native password-change API instead.
+
+## Uninstall
+
+```bash
+sudo ./uninstall.sh
+```
+
+Keep the environment file for inspection:
+
+```bash
+sudo KEEP_ENV=true ./uninstall.sh
+```
+
+## Notes
+
+- This helper is only for Authelia's file backend.
+- For LDAP or SQL-backed user providers, implement password changes in that backend instead.
+- This helper intentionally does not implement registration, password reset, or second-factor management.

--- a/examples/file-backend-password-helper/authelia_file_backend_password_helper.py
+++ b/examples/file-backend-password-helper/authelia_file_backend_password_helper.py
@@ -213,6 +213,9 @@ class Handler(BaseHTTPRequestHandler):
         if not self._precheck():
             return
         if self.path == "/health":
+            if not verify_bearer(self):
+                json_response(self, 403, {"status": "KO", "message": "forbidden"})
+                return
             json_response(self, 200, {"status": "OK"})
             return
         json_response(self, 404, {"status": "KO", "message": "not found"})

--- a/examples/file-backend-password-helper/authelia_file_backend_password_helper.py
+++ b/examples/file-backend-password-helper/authelia_file_backend_password_helper.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""
+Authelia file-backend password change helper.
+
+This is a pragmatic homelab workaround for Authelia file-backend setups where
+users have no deliverable email address for Elevated Session One-Time Codes.
+
+Security model:
+  - Jellyfin sends username/current password/new password to this helper.
+  - Helper verifies the current password via Authelia /api/firstfactor.
+  - Helper updates only the user's password hash in users_database.yml.
+  - Helper restarts Authelia so the new file-backend hash is loaded.
+
+This is NOT a general upstream Authelia replacement. Keep it private.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+BIND_HOST = os.environ.get("BIND_HOST", "127.0.0.1")
+PORT = int(os.environ.get("PORT", "9944"))
+HELPER_TOKEN = os.environ.get("HELPER_TOKEN", "")
+ALLOWED_CLIENTS = os.environ.get("ALLOWED_CLIENTS", "")
+AUTHELIA_BASE = os.environ.get("AUTHELIA_BASE", "https://auth.example.com")
+TARGET_URL = os.environ.get("TARGET_URL", "https://jellyfin.example.com/")
+USERS_DB = Path(os.environ.get("USERS_DB", "/opt/authelia/config/users_database.yml"))
+AUTHELIA_CONTAINER = os.environ.get("AUTHELIA_CONTAINER", "authelia")
+MIN_PASSWORD_LENGTH = int(os.environ.get("MIN_PASSWORD_LENGTH", "8"))
+
+
+def log(message: str) -> None:
+    print(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] {message}", flush=True)
+
+
+def parse_allowed_clients() -> list[ipaddress._BaseNetwork]:
+    networks = []
+    for raw in ALLOWED_CLIENTS.split(","):
+        item = raw.strip()
+        if not item:
+            continue
+        if "/" not in item:
+            item = item + ("/32" if ":" not in item else "/128")
+        networks.append(ipaddress.ip_network(item, strict=False))
+    return networks
+
+
+ALLOWED_NETWORKS = parse_allowed_clients()
+
+
+def client_allowed(address: str) -> bool:
+    if not ALLOWED_NETWORKS:
+        return True
+    ip = ipaddress.ip_address(address)
+    return any(ip in network for network in ALLOWED_NETWORKS)
+
+
+def json_response(handler: BaseHTTPRequestHandler, status: int, payload: dict) -> None:
+    raw = json.dumps(payload).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(raw)))
+    handler.end_headers()
+    handler.wfile.write(raw)
+
+
+def verify_bearer(handler: BaseHTTPRequestHandler) -> bool:
+    if not HELPER_TOKEN:
+        return True
+    return handler.headers.get("Authorization", "") == f"Bearer {HELPER_TOKEN}"
+
+
+def authelia_firstfactor(username: str, password: str) -> bool:
+    payload = json.dumps(
+        {
+            "username": username,
+            "password": password,
+            "targetURL": TARGET_URL,
+            "requestMethod": "GET",
+            "keepMeLoggedIn": False,
+        }
+    )
+
+    proc = subprocess.run(
+        [
+            "curl",
+            "-sk",
+            "--max-time",
+            "20",
+            "-o",
+            "/dev/null",
+            "-w",
+            "%{http_code}",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            payload,
+            f"{AUTHELIA_BASE.rstrip('/')}/api/firstfactor",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"firstfactor curl failed: {proc.stderr.strip()[:200]}")
+    return proc.stdout.strip() == "200"
+
+
+def generate_argon2_hash(password: str) -> str:
+    # Authelia v4.39 CLI has --password but no stdin password option. Running
+    # this helper as a private locked-down service is mandatory because the
+    # password may briefly be visible to privileged process inspection.
+    proc = subprocess.run(
+        [
+            "docker",
+            "exec",
+            AUTHELIA_CONTAINER,
+            "authelia",
+            "crypto",
+            "hash",
+            "generate",
+            "argon2",
+            "--password",
+            password,
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"hash generation failed: {proc.stderr.strip()[:200]}")
+    match = re.search(r"Digest:\s*(\S+)", proc.stdout)
+    if not match:
+        raise RuntimeError("hash generation produced no Digest line")
+    return match.group(1)
+
+
+def replace_user_password(username: str, digest: str) -> None:
+    if not re.fullmatch(r"[A-Za-z0-9_.@-]{1,128}", username):
+        raise ValueError("invalid username format")
+
+    original = USERS_DB.read_text(encoding="utf-8").splitlines()
+    out: list[str] = []
+    in_user = False
+    found_user = False
+    replaced = False
+
+    user_header = f"    {username}:"
+    for line in original:
+        if line.startswith("    ") and not line.startswith("        ") and line.rstrip().endswith(":"):
+            in_user = line == user_header
+            if in_user:
+                found_user = True
+
+        if in_user and line.startswith("        password:"):
+            out.append(f"        password: {digest}")
+            replaced = True
+        else:
+            out.append(line)
+
+    if not found_user:
+        raise ValueError("user not found in users_database.yml")
+    if not replaced:
+        raise ValueError("password field not found for user")
+
+    backup = USERS_DB.with_suffix(USERS_DB.suffix + f".bak.helper-{username}.{int(time.time())}")
+    shutil.copy2(USERS_DB, backup)
+
+    fd, tmp_name = tempfile.mkstemp(prefix=USERS_DB.name + ".", dir=str(USERS_DB.parent))
+    with os.fdopen(fd, "w", encoding="utf-8") as tmp:
+        tmp.write("\n".join(out).rstrip() + "\n")
+    os.replace(tmp_name, USERS_DB)
+    log(f"updated password hash for user={username}; backup={backup.name}")
+
+
+def restart_authelia() -> None:
+    proc = subprocess.run(
+        ["docker", "restart", AUTHELIA_CONTAINER],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"docker restart failed: {proc.stderr.strip()[:200]}")
+    time.sleep(3)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt: str, *args) -> None:  # noqa: A003
+        log(f"{self.client_address[0]} {fmt % args}")
+
+    def _precheck(self) -> bool:
+        if not client_allowed(self.client_address[0]):
+            json_response(self, 403, {"status": "KO", "message": "client not allowed"})
+            return False
+        return True
+
+    def do_GET(self) -> None:  # noqa: N802
+        if not self._precheck():
+            return
+        if self.path == "/health":
+            json_response(self, 200, {"status": "OK"})
+            return
+        json_response(self, 404, {"status": "KO", "message": "not found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        if not self._precheck():
+            return
+        if self.path != "/change-password":
+            json_response(self, 404, {"status": "KO", "message": "not found"})
+            return
+        if not verify_bearer(self):
+            json_response(self, 403, {"status": "KO", "message": "forbidden"})
+            return
+
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            if length <= 0 or length > 16384:
+                json_response(self, 400, {"status": "KO", "message": "invalid body length"})
+                return
+            body = json.loads(self.rfile.read(length).decode("utf-8"))
+            username = str(body.get("username", ""))
+            old_password = str(body.get("old_password", ""))
+            new_password = str(body.get("new_password", ""))
+
+            if not username or not old_password or not new_password:
+                json_response(self, 400, {"status": "KO", "message": "username, old_password, and new_password are required"})
+                return
+            if len(new_password) < MIN_PASSWORD_LENGTH:
+                json_response(self, 400, {"status": "KO", "message": f"new password must be at least {MIN_PASSWORD_LENGTH} characters"})
+                return
+
+            if not authelia_firstfactor(username, old_password):
+                json_response(self, 401, {"status": "KO", "message": "invalid username or password"})
+                return
+
+            digest = generate_argon2_hash(new_password)
+            replace_user_password(username, digest)
+            restart_authelia()
+            json_response(self, 200, {"status": "OK", "message": "password changed"})
+        except Exception as exc:  # intentionally do not log credential values
+            log(f"change-password failed: {type(exc).__name__}: {exc}")
+            json_response(self, 500, {"status": "KO", "message": "internal helper error"})
+
+
+def main() -> None:
+    if not HELPER_TOKEN:
+        log("WARNING: HELPER_TOKEN is empty; do not expose this service")
+    log(f"allowed_clients={ALLOWED_CLIENTS or '<disabled>'}")
+    server = ThreadingHTTPServer((BIND_HOST, PORT), Handler)
+    log(f"listening on {BIND_HOST}:{PORT}; authelia_base={AUTHELIA_BASE}; users_db={USERS_DB}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/file-backend-password-helper/install.sh
+++ b/examples/file-backend-password-helper/install.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Origin: GPT-5.3 Codex
+# Context: Optional Authelia file-backend password helper
+# Target: Authelia host/container host running systemd and Docker
+# Purpose: Install helper as systemd service with bearer token and optional IP allowlist
+
+set -euo pipefail
+
+INSTALL_DIR="${INSTALL_DIR:-/opt/authelia-password-helper}"
+ENV_FILE="${ENV_FILE:-/etc/authelia-password-helper.env}"
+SERVICE_FILE="${SERVICE_FILE:-/etc/systemd/system/authelia-password-helper.service}"
+HELPER_SOURCE="$(cd "$(dirname "$0")" && pwd)/authelia_file_backend_password_helper.py"
+
+BIND_HOST="${BIND_HOST:-127.0.0.1}"
+PORT="${PORT:-9944}"
+AUTHELIA_BASE="${AUTHELIA_BASE:-https://auth.example.com}"
+TARGET_URL="${TARGET_URL:-https://jellyfin.example.com/}"
+USERS_DB="${USERS_DB:-/opt/authelia/config/users_database.yml}"
+AUTHELIA_CONTAINER="${AUTHELIA_CONTAINER:-authelia}"
+ALLOWED_CLIENTS="${ALLOWED_CLIENTS:-}"
+MIN_PASSWORD_LENGTH="${MIN_PASSWORD_LENGTH:-8}"
+
+section() { echo; echo "===== $* ====="; }
+fail() { echo "FAIL: $*"; exit 1; }
+pass() { echo "PASS: $*"; }
+
+[ "$(id -u)" = "0" ] || fail "Run as root"
+[ -f "$HELPER_SOURCE" ] || fail "Helper source not found: $HELPER_SOURCE"
+command -v systemctl >/dev/null || fail "systemctl not found"
+command -v docker >/dev/null || fail "docker not found"
+
+if [ -z "${HELPER_TOKEN:-}" ]; then
+  if command -v openssl >/dev/null; then
+    HELPER_TOKEN="$(openssl rand -hex 32)"
+  else
+    HELPER_TOKEN="$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+  fi
+  GENERATED_TOKEN="yes"
+else
+  GENERATED_TOKEN="no"
+fi
+
+section "Install files"
+install -d -m 0750 "$INSTALL_DIR"
+install -m 0750 "$HELPER_SOURCE" "$INSTALL_DIR/authelia_file_backend_password_helper.py"
+
+section "Write environment"
+cat > "$ENV_FILE" <<EOF
+BIND_HOST=${BIND_HOST}
+PORT=${PORT}
+HELPER_TOKEN=${HELPER_TOKEN}
+ALLOWED_CLIENTS=${ALLOWED_CLIENTS}
+AUTHELIA_BASE=${AUTHELIA_BASE}
+TARGET_URL=${TARGET_URL}
+USERS_DB=${USERS_DB}
+AUTHELIA_CONTAINER=${AUTHELIA_CONTAINER}
+MIN_PASSWORD_LENGTH=${MIN_PASSWORD_LENGTH}
+EOF
+chmod 0600 "$ENV_FILE"
+
+section "Write systemd unit"
+cat > "$SERVICE_FILE" <<EOF
+[Unit]
+Description=Authelia File Backend Password Change Helper
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=simple
+User=root
+Group=root
+EnvironmentFile=${ENV_FILE}
+ExecStart=/usr/bin/env python3 ${INSTALL_DIR}/authelia_file_backend_password_helper.py
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+[Install]
+WantedBy=multi-user.target
+EOF
+chmod 0644 "$SERVICE_FILE"
+
+section "Enable service"
+systemctl daemon-reload
+systemctl enable --now authelia-password-helper.service
+sleep 2
+systemctl --no-pager --full status authelia-password-helper.service || true
+
+section "Health check"
+if curl -sk --max-time 10 "http://${BIND_HOST}:${PORT}/health" | grep -q '"OK"'; then
+  pass "Helper health endpoint is reachable locally"
+else
+  fail "Helper health endpoint failed"
+fi
+
+section "Done"
+pass "Installed authelia-password-helper"
+echo "HELPER_URL=http://${BIND_HOST}:${PORT}"
+if [ "$GENERATED_TOKEN" = "yes" ]; then
+  echo "GENERATED_HELPER_TOKEN=${HELPER_TOKEN}"
+  echo "Store this token in Jellyfin plugin config: Password change helper bearer token"
+else
+  echo "HELPER_TOKEN_PROVIDED=yes"
+fi
+if [ -n "$ALLOWED_CLIENTS" ]; then
+  echo "ALLOWED_CLIENTS=${ALLOWED_CLIENTS}"
+else
+  echo "ALLOWED_CLIENTS=<disabled>"
+fi

--- a/examples/file-backend-password-helper/install.sh
+++ b/examples/file-backend-password-helper/install.sh
@@ -91,7 +91,7 @@ sleep 2
 systemctl --no-pager --full status authelia-password-helper.service || true
 
 section "Health check"
-if curl -sk --max-time 10 "http://${BIND_HOST}:${PORT}/health" | grep -q '"OK"'; then
+if curl -sk --max-time 10 -H "Authorization: Bearer ${HELPER_TOKEN}" "http://${BIND_HOST}:${PORT}/health" | grep -q '"OK"'; then
   pass "Helper health endpoint is reachable locally"
 else
   fail "Helper health endpoint failed"

--- a/examples/file-backend-password-helper/install.sh
+++ b/examples/file-backend-password-helper/install.sh
@@ -85,7 +85,8 @@ chmod 0644 "$SERVICE_FILE"
 
 section "Enable service"
 systemctl daemon-reload
-systemctl enable --now authelia-password-helper.service
+systemctl enable authelia-password-helper.service
+systemctl restart authelia-password-helper.service
 sleep 2
 systemctl --no-pager --full status authelia-password-helper.service || true
 

--- a/examples/file-backend-password-helper/uninstall.sh
+++ b/examples/file-backend-password-helper/uninstall.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Origin: GPT-5.3 Codex
+# Context: Optional Authelia file-backend password helper
+# Target: Authelia host/container host running systemd
+# Purpose: Disable and remove helper service files
+
+set -euo pipefail
+
+INSTALL_DIR="${INSTALL_DIR:-/opt/authelia-password-helper}"
+ENV_FILE="${ENV_FILE:-/etc/authelia-password-helper.env}"
+SERVICE_FILE="${SERVICE_FILE:-/etc/systemd/system/authelia-password-helper.service}"
+KEEP_ENV="${KEEP_ENV:-false}"
+
+section() { echo; echo "===== $* ====="; }
+pass() { echo "PASS: $*"; }
+
+[ "$(id -u)" = "0" ] || { echo "FAIL: Run as root"; exit 1; }
+
+section "Stop service"
+systemctl disable --now authelia-password-helper.service 2>/dev/null || true
+
+section "Remove files"
+rm -f "$SERVICE_FILE"
+rm -rf "$INSTALL_DIR"
+if [ "$KEEP_ENV" = "true" ]; then
+  echo "Keeping env file: $ENV_FILE"
+else
+  rm -f "$ENV_FILE"
+fi
+
+section "Reload systemd"
+systemctl daemon-reload
+systemctl reset-failed authelia-password-helper.service 2>/dev/null || true
+
+section "Done"
+pass "Removed authelia-password-helper"


### PR DESCRIPTION
## Status
**Updated 2026-06-07:** Full E2E pipeline verified on production infrastructure.

## What this branch does
- implements provider \ChangePassword\ for Authelia-backed users
- adds explicit Authelia elevation handling for password changes
- supports one-time-code retry using \currentPassword::otc=YOURCODE\
- calls Authelia elevation endpoint (\PUT /api/user/session/elevation\) before retrying \POST /api/change-password\
- improves error messages with actionable retry guidance and truncated upstream response details
- documents the Jellyfin <-> Authelia password-change flow and security constraints in README
- **NEW:** Optional \PasswordChangeHelperUrl\/\PasswordChangeHelperToken\ plugin config for file-backend users without email/OTC capability
- **NEW:** Self-contained password helper (\examples/file-backend-password-helper/\) deployed as systemd service with IP allowlist + bearer token

## The Challenge
Authelia's password-change endpoint is protected by elevated-session identity validation:
- 1FA-only direct password change is rejected with \403\.
- Email One-Time Code elevation works, but requires a deliverable email address.

This means users without a valid email in Authelia cannot change their password from Jellyfin WebUI -- a common homelab scenario.

## Two-Pronged Solution

### 1. OTC Elevation Path (Standard)
- \POST /api/user/session/elevation\ to start elevation
- OTC email extraction and retry with \currentPassword::otc=YOURCODE\
- E2E validated: \LOGIN_BEFORE_HTTP=200\ -> \CHANGE_HTTP=204\ -> \LOGIN_OLD_AFTER_HTTP=401\ -> \LOGIN_NEW_AFTER_HTTP=200\

### 2. File-Backend Helper Path (Workaround for users without email)
A companion helper service running on the Authelia host validates passwords locally via \docker exec authelia authelia crypto hash validate\ (eliminating session-domain issues with HTTP API) and writes directly to \users_database.yml\.

**E2E pipeline verified 2026-06-07:**
\\\
BEFORE_OLD=200 -> HELPER=200 -> AFTER_OLD=401 -> AFTER_NEW=200 -> RESTORE=200 -> RESTORED=200
\\\

Deployment: systemd service on Authelia CT, accessible via private IP \192.168.100.4:9944\, bearer-token protected, IP-allowlisted.

## Validated Scenarios
- \dotnet build Authelia-Auth.sln -c Release\ passed
- \dotnet test Authelia-Auth.sln -c Release\ passed (existing upstream test remains skipped)
- Production E2E with extracted OTC: all 4 checks passed
- Production E2E with file-backend helper: all 6 checks passed
- CoVe matrix confirmed:
  - \RESULT_A_FIRSTFACTOR_ONLY_CHANGE_HTTP=403\
  - \RESULT_B_SECONDF_PASSWORD_HTTP=200\ / \CHANGE_AFTER_SECONDFACTOR_HTTP=403\
  - \RESULT_C_ELEVATION_START_HTTP=200\ / \VERIFY_OTC_HTTP=200\ / \CHANGE_AFTER_OTC_HTTP=200\

## Security
- credentials are not persisted; they are request-scoped and consumed in-flow
- OTC and password buffers are cleared after use
- helper requires bearer token + client IP allowlist (no public exposure)
- Travis CI: file-based config merged, no original files removed
